### PR TITLE
typo

### DIFF
--- a/r-local-development.md
+++ b/r-local-development.md
@@ -1,6 +1,6 @@
 ---
 title: "Local development R package"
-Author: ["Simone Massaro", "Sam Herniman", "Anna Dodd]
+Author: ["Simone Massaro", "Sam Herniman", "Anna Dodd"]
 Date: 05 August 2025
 ---
 


### PR DESCRIPTION
Fixed typo.
Should r-local-development.md be a qmd?